### PR TITLE
feat: Use feature_type from metadata instead of hardcoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -610,9 +610,9 @@ checksum = "645cbb3a84e60b7531617d5ae4e57f7e27308f6445f5abf653209ea76dec8dff"
 
 [[package]]
 name = "flagsmith-flag-engine"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf3f7915c7365497f69816a41948ca23fa24f131fcf7c0c1b5aa2200fd57ccb4"
+checksum = "8506a1a6efe91540e5fa399f3d1ff1c1c756e431a2c8010885618b6a3d5da206"
 dependencies = [
  "chrono",
  "md-5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ async-trait = "0.1"
 lru = "0.16"
 http = "1"
 validator = { version = "0.20", features = ["derive"] }
-flagsmith-flag-engine = "0.5"
+flagsmith-flag-engine = "0.6"
 
 [dev-dependencies]
 axum-test = "18"

--- a/src/models/response.rs
+++ b/src/models/response.rs
@@ -27,7 +27,7 @@ impl From<&FlagResult> for APIFeatureState {
             feature: APIFeature {
                 id: flag_result.metadata.feature_id as i64,
                 name: flag_result.name.clone(),
-                feature_type: Cow::Borrowed("STANDARD"),
+                feature_type: Cow::Owned(flag_result.metadata.feature_type.clone()),
             },
             feature_state_value: json_value,
         }

--- a/src/services/feature_utils.rs
+++ b/src/services/feature_utils.rs
@@ -25,7 +25,10 @@ mod tests {
                 value: format!("value{}", id),
             },
             reason: "DEFAULT".to_string(),
-            metadata: FeatureMetadata { feature_id: id },
+            metadata: FeatureMetadata {
+                feature_id: id,
+                feature_type: "STANDARD".to_string(),
+            },
         }
     }
 


### PR DESCRIPTION
## Summary

- Bump flagsmith-flag-engine to 0.6.0 which includes `feature_type` in `FeatureMetadata`
- Update response conversion to use the actual `feature_type` from metadata instead of hardcoding "STANDARD"