### PR TITLE
fix: Use correct DockerHub credential variable names

### DIFF
--- a/.github/workflows/docker-publish-image.yml
+++ b/.github/workflows/docker-publish-image.yml
@@ -35,8 +35,8 @@ jobs:
       - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ vars.DOCKERHUB_USERNAME_WRITE }}
+          password: ${{ secrets.DOCKERHUB_TOKEN_WRITE }}
 
       - name: Build and push
         uses: docker/build-push-action@v6


### PR DESCRIPTION
## Summary

Update Docker publish workflow to use the correct credential variable names that are configured in the Flagsmith organization:

- `DOCKERHUB_USERNAME` → `DOCKERHUB_USERNAME_WRITE`
- `DOCKERHUB_TOKEN` → `DOCKERHUB_TOKEN_WRITE`

This matches the pattern used in other Flagsmith repos like edge-proxy.